### PR TITLE
Updates MongoDB installation script for RHEL9

### DIFF
--- a/scripts/mongo-magic/.mongo-magic.sh
+++ b/scripts/mongo-magic/.mongo-magic.sh
@@ -14,7 +14,10 @@
 # Features:
 # - Detects the server's OS/architecture and asks MongoDB's official release
 #   catalog (downloads.mongodb.org) which binary actually matches it, instead
-#   of guessing a filename. Aborts instead of installing the wrong binary.
+#   of guessing a filename. When the OS isn't one MongoDB publishes a build
+#   for (e.g. Zone.eu's own ZoneOS), it probes a list of known-compatible
+#   builds and verifies each one by actually running mongod, rather than
+#   trusting a name match. Aborts only if nothing it tries will run.
 # - Verifies the SHA-256 checksum of every downloaded artifact.
 # - Lets you choose between MongoDB 8.0 (current Long-Term/Major Release,
 #   recommended) and 7.0 (previous Major Release, still supported).
@@ -160,6 +163,14 @@ detect_os_key() {
     local major="${version%%.*}"
 
     case "$id" in
+        zoneos)
+            # Zone.eu's own ZoneOS host image: a Gentoo/ChromiumOS-derived,
+            # rpm/dpkg-less system (see ZONEOS_BOARD in /etc/os-release) that
+            # has no equivalent target in MongoDB's release catalog. Don't
+            # guess one here -- leave OS_KEY empty and let the FALLBACK_TARGETS
+            # probe below find a build that actually runs, verified by
+            # execution rather than by name.
+            echo "" ;;
         rhel|centos|rocky|almalinux|ol|fedora)
             echo "rhel${major}" ;;
         ubuntu)
@@ -194,12 +205,35 @@ detect_arch() {
 OS_KEY=$(detect_os_key)
 ARCH=$(detect_arch)
 
-if [ -z "$OS_KEY" ] || [ -z "$ARCH" ]; then
-    error "Could not confidently detect this server's OS/architecture."
+if [ -z "$ARCH" ]; then
+    error "Could not detect this server's CPU architecture (uname -m: $(uname -m))."
     error "Please check https://www.mongodb.com/try/download/community-edition and install manually."
     exit 1
 fi
-info "Detected platform: ${OS_KEY} / ${ARCH}"
+
+# Targets to try, in order, against MongoDB's release catalog. The detected
+# OS_KEY (if any) is always tried first; the rest are a fallback list for
+# hosts we can't confidently name -- e.g. Zone.eu's own ZoneOS, which isn't
+# a distro MongoDB has ever heard of. Every candidate is downloaded and
+# smoke-tested with `mongod --version` before being trusted (see below), so
+# a wrong guess here just moves on to the next one instead of silently
+# installing a binary that can't run.
+FALLBACK_TARGETS=(rhel9 ubuntu2404 debian12 amazon2023 ubuntu2204 rhel8 debian11)
+
+CANDIDATES=()
+[ -n "$OS_KEY" ] && CANDIDATES+=("$OS_KEY")
+for t in "${FALLBACK_TARGETS[@]}"; do
+    [ "$t" != "$OS_KEY" ] && CANDIDATES+=("$t")
+done
+
+if [ -n "$OS_KEY" ]; then
+    info "Detected platform: ${OS_KEY} / ${ARCH}"
+else
+    OS_NAME=""
+    [ -r /etc/os-release ] && OS_NAME=$(. /etc/os-release; echo "${PRETTY_NAME:-$ID}")
+    warn "Could not map this server's OS${OS_NAME:+ ($OS_NAME)} to a MongoDB release-catalog target directly."
+    warn "Will probe known-compatible builds (${CANDIDATES[*]}) and use whichever one actually runs here."
+fi
 
 # mongosh's feed labels ARM as "arm64" instead of "aarch64"
 MONGOSH_ARCH="$ARCH"
@@ -291,37 +325,53 @@ esac
 # ---------------------------------------------------------------------------
 # RESOLVE & DOWNLOAD MONGODB SERVER
 # ---------------------------------------------------------------------------
-info "Looking up the correct MongoDB ${MONGO_BRANCH} build for this server..."
+info "Looking up a MongoDB ${MONGO_BRANCH} build for this server..."
 SERVER_FEED="$SCRATCH_DIR/current.json"
 download "https://downloads.mongodb.org/current.json" "$SERVER_FEED"
-
-if ! RESULT=$(resolve_download "$SERVER_FEED" "$ARCH" target "$OS_KEY" "" "$MONGO_BRANCH" targeted); then
-    error "Could not find a MongoDB ${MONGO_BRANCH} build for ${OS_KEY}/${ARCH} in MongoDB's release catalog."
-    error "Please check https://www.mongodb.com/try/download/community-edition and install manually."
-    exit 1
-fi
-IFS=$'\t' read -r MONGO_VERSION MONGO_URL MONGO_SHA256 <<< "$RESULT"
-info "Resolved MongoDB ${MONGO_VERSION} (${MONGO_URL})"
 
 # CREATE REQUIRED DIRS
 mkdir -p "$MONGODB_DIR/log" "$MONGODB_DIR/run" "$MONGODB_DIR/db" "$MONGODB_DIR/mongosh" "$MONGODB_DIR/tools"
 cd "$MONGODB_DIR" || { error "Failed to change directory!"; exit 1; }
 
-MONGO_ARCHIVE="$SCRATCH_DIR/$(basename "$MONGO_URL")"
-download "$MONGO_URL" "$MONGO_ARCHIVE"
-verify_checksum "$MONGO_ARCHIVE" "$MONGO_SHA256"
-tar -zxf "$MONGO_ARCHIVE" -C "$MONGODB_DIR"
+MONGO_VERSION="" MONGO_TARGET=""
+for candidate in "${CANDIDATES[@]}"; do
+    if ! RESULT=$(resolve_download "$SERVER_FEED" "$ARCH" target "$candidate" "" "$MONGO_BRANCH" targeted); then
+        continue
+    fi
+    IFS=$'\t' read -r c_version c_url c_sha256 <<< "$RESULT"
 
-set +o pipefail
-EXTRACTED_DIR=$(tar -tzf "$MONGO_ARCHIVE" | head -n 1 | cut -d/ -f1)
-set -o pipefail
-ln -sfn "$MONGODB_DIR/$EXTRACTED_DIR" "$MONGODB_DIR/mongodb-binary"
+    info "Trying MongoDB ${c_version} ('${candidate}' build)..."
+    c_archive="$SCRATCH_DIR/$(basename "$c_url")"
+    download "$c_url" "$c_archive"
+    verify_checksum "$c_archive" "$c_sha256"
 
-if ! "$MONGODB_DIR/mongodb-binary/bin/mongod" --version > /dev/null 2>&1; then
-    error "The downloaded mongod binary failed to run on this system (missing shared libraries?)."
+    set +o pipefail
+    c_dir=$(tar -tzf "$c_archive" | head -n 1 | cut -d/ -f1)
+    set -o pipefail
+    rm -rf "$SCRATCH_DIR/probe"
+    mkdir -p "$SCRATCH_DIR/probe"
+    tar -zxf "$c_archive" -C "$SCRATCH_DIR/probe"
+
+    if "$SCRATCH_DIR/probe/$c_dir/bin/mongod" --version > /dev/null 2>&1; then
+        rm -rf "$MONGODB_DIR/$c_dir"
+        mv "$SCRATCH_DIR/probe/$c_dir" "$MONGODB_DIR/$c_dir"
+        ln -sfn "$MONGODB_DIR/$c_dir" "$MONGODB_DIR/mongodb-binary"
+        MONGO_VERSION="$c_version"
+        MONGO_TARGET="$candidate"
+        rm -f "$c_archive"
+        info "MongoDB ${MONGO_VERSION} ('${candidate}' build) downloaded, verified, and confirmed runnable."
+        break
+    fi
+
+    warn "'${candidate}' build downloaded but mongod couldn't run here (likely missing shared libraries); trying next candidate."
+    rm -rf "$SCRATCH_DIR/probe" "$c_archive"
+done
+
+if [ -z "$MONGO_VERSION" ]; then
+    error "None of the candidate MongoDB ${MONGO_BRANCH} builds (${CANDIDATES[*]}) would run on this server."
+    error "Please check https://www.mongodb.com/try/download/community-edition and install manually."
     exit 1
 fi
-info "MongoDB ${MONGO_VERSION} downloaded and verified."
 
 # ---------------------------------------------------------------------------
 # RESOLVE & DOWNLOAD MONGOSH
@@ -349,15 +399,34 @@ info "Fetching the latest MongoDB Database Tools build..."
 TOOLS_FEED="$SCRATCH_DIR/tools-release.json"
 download "https://downloads.mongodb.org/tools/db/release.json" "$TOOLS_FEED"
 
-if RESULT=$(resolve_download "$TOOLS_FEED" "$ARCH" name "$OS_KEY" "" "" ""); then
-    IFS=$'\t' read -r TOOLS_VERSION TOOLS_URL TOOLS_SHA256 <<< "$RESULT"
-    TOOLS_ARCHIVE="$SCRATCH_DIR/tools.tgz"
-    download "$TOOLS_URL" "$TOOLS_ARCHIVE"
-    verify_checksum "$TOOLS_ARCHIVE" "$TOOLS_SHA256"
-    tar -zxf "$TOOLS_ARCHIVE" -C "$MONGODB_DIR/tools" --strip-components=1
-    info "MongoDB Database Tools ${TOOLS_VERSION} installed."
-else
-    warn "Could not find a matching MongoDB Database Tools build for ${OS_KEY}/${ARCH}. Skipping (optional)."
+TOOLS_VERSION=""
+for candidate in "${CANDIDATES[@]}"; do
+    if ! RESULT=$(resolve_download "$TOOLS_FEED" "$ARCH" name "$candidate" "" "" ""); then
+        continue
+    fi
+    IFS=$'\t' read -r c_version c_url c_sha256 <<< "$RESULT"
+    c_archive="$SCRATCH_DIR/tools.tgz"
+    download "$c_url" "$c_archive"
+    verify_checksum "$c_archive" "$c_sha256"
+
+    rm -rf "$MONGODB_DIR/tools"
+    mkdir -p "$MONGODB_DIR/tools"
+    tar -zxf "$c_archive" -C "$MONGODB_DIR/tools" --strip-components=1
+    rm -f "$c_archive"
+
+    if "$MONGODB_DIR/tools/bin/mongodump" --version > /dev/null 2>&1; then
+        TOOLS_VERSION="$c_version"
+        info "MongoDB Database Tools ${TOOLS_VERSION} ('${candidate}' build) installed and confirmed runnable."
+        break
+    fi
+
+    warn "Database Tools '${candidate}' build couldn't run here; trying next candidate."
+    rm -rf "$MONGODB_DIR/tools"
+done
+
+if [ -z "$TOOLS_VERSION" ]; then
+    warn "Could not find a working MongoDB Database Tools build for this server. Skipping (optional)."
+    mkdir -p "$MONGODB_DIR/tools"
 fi
 
 # ---------------------------------------------------------------------------
@@ -532,6 +601,7 @@ fi
 # WRAP UP
 # ---------------------------------------------------------------------------
 info "MongoDB installation completed successfully."
+echo "MongoDB version: $MONGO_VERSION (using the '${MONGO_TARGET}' build)"
 sleep 1
 warn "IMPORTANT: Setup MongoDB as new PM2 app at Zone.eu"
 echo "Webhosting -> PM2 and Node.js -> Add new application"

--- a/scripts/mongo-magic/.mongo-magic.sh
+++ b/scripts/mongo-magic/.mongo-magic.sh
@@ -1,7 +1,7 @@
-#! /usr/bin/bash
+#!/usr/bin/env bash
 
 # Install MongoDB on Zone.eu servers automatically.
-# 
+#
 # Usage:
 # 1. Copy the script (.mongo-magic.sh) into your HOME directory (e.g., /data01/virt12345/).
 # 2. Run the script from the terminal using: "bash .mongo-magic.sh".
@@ -12,105 +12,393 @@
 # - curl: curl -O https://raw.githubusercontent.com/raidokulla/mongo-magic/master/.mongo-magic.sh
 #
 # Features:
+# - Detects the server's OS/architecture and asks MongoDB's official release
+#   catalog (downloads.mongodb.org) which binary actually matches it, instead
+#   of guessing a filename. Aborts instead of installing the wrong binary.
+# - Verifies the SHA-256 checksum of every downloaded artifact.
+# - Lets you choose between MongoDB 8.0 (current Long-Term/Major Release,
+#   recommended) and 7.0 (previous Major Release, still supported).
+# - Always fetches the latest mongosh and MongoDB Database Tools builds.
 # - Checks for an existing MongoDB instance and prevents conflicts.
 # - Offers to back up the current database before installation.
-# - Allows the user to choose between MongoDB versions 6.0 and 7.0.
-# - Lets the user select the memory allocation for MongoDB from predefined options (256M, 512M, 1G, 2G, 3G).
+# - Scales the WiredTiger cache to the chosen PM2 memory limit so MongoDB
+#   doesn't get killed in a restart loop on small memory plans.
+# - Lets the user select the memory allocation for MongoDB (256M, 512M, 1G, 2G, 3G).
 # - Enables the user to specify a custom PM2 app name.
-# - Automatically checks for compatible MongoDB tools and installs them.
-# - Prompts for the creation of a new user with root access and an optional additional user with read/write permissions.
-# - Prompts the user to name the new database with limited access.
+# - Prompts for the creation of a new root user, and an optional additional
+#   user with read/write permissions on a database of their choice.
 # - Provides instructions for setting up MongoDB as a new PM2 app on Zone.eu servers.
-# - Adds the mongosh binary to the PATH for easy access.
+# - Adds mongosh and the database tools to PATH for easy access.
 #
 # Author: Raido K @ Vellex Digital
 # GitHub: https://github.com/raidokulla
 
-# DEFINE COLORS
+set -Eeuo pipefail
+
+# ---------------------------------------------------------------------------
+# COLORS & OUTPUT HELPERS
+# ---------------------------------------------------------------------------
 RED="\033[0;31m"
 GREEN="\033[0;32m"
 YELLOW="\033[0;33m"
-RESET="\033[0m"  # Reset to default color
+RESET="\033[0m"
 
+info()    { echo -e "${GREEN}$*${RESET}"; }
+warn()    { echo -e "${YELLOW}$*${RESET}"; }
+error()   { echo -e "${RED}$*${RESET}" >&2; }
+confirm() { local reply; read -r -p "$1 (y/n): " reply; [[ "$reply" =~ ^[Yy]$ ]]; }
+
+trap 'error "Something went wrong on line $LINENO. Aborting."' ERR
+
+SCRATCH_DIR=$(mktemp -d "${TMPDIR:-/tmp}/mongo-magic.XXXXXX")
+trap 'rm -rf "$SCRATCH_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# PREREQUISITE CHECKS
+# ---------------------------------------------------------------------------
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || { error "Required command '$1' was not found. This script is intended for Zone.eu servers."; exit 1; }
+}
+
+require_command pm2
+require_command node
+require_command tar
+require_command vs-loopback-ip
+
+if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+    error "Neither curl nor wget is available. Cannot download MongoDB."
+    exit 1
+fi
+
+download() {
+    local url="$1" dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fSL --retry 3 --retry-delay 2 -o "$dest" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q -O "$dest" "$url"
+    else
+        error "Neither curl nor wget is available to download files."
+        exit 1
+    fi
+}
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$1" | awk '{print $NF}'
+    fi
+}
+
+verify_checksum() {
+    local file="$1" expected="$2" actual
+    if [ -z "$expected" ]; then
+        warn "No checksum provided for $(basename "$file"), skipping verification."
+        return 0
+    fi
+    actual=$(sha256_of "$file")
+    if [ -z "$actual" ]; then
+        warn "No SHA-256 tool (sha256sum/shasum/openssl) found, skipping verification of $(basename "$file")."
+        return 0
+    fi
+    if [ "$actual" != "$expected" ]; then
+        error "Checksum mismatch for $(basename "$file")! Expected $expected, got $actual."
+        error "The download may be corrupted or tampered with. Aborting."
+        exit 1
+    fi
+    info "Checksum verified for $(basename "$file")."
+}
+
+# ---------------------------------------------------------------------------
 # START SCRIPT
-echo -e "${GREEN}Welcome to the MongoDB installation script!${RESET}"
+# ---------------------------------------------------------------------------
+info "Welcome to the MongoDB installation script!"
 echo "This script will help you install MongoDB on your Zone.eu server."
 echo "Sit back and relax while we take care of everything for you."
 sleep 1
 
-# GET LOOPBACK IP
 LOOPBACK=$(vs-loopback-ip -4)
+if [ -z "$LOOPBACK" ]; then
+    error "vs-loopback-ip returned no address. Are you running this on a Zone.eu server?"
+    exit 1
+fi
 MONGODB_DIR="$HOME/mongodb"
 
-# Check if MongoDB is running
+# Check if MongoDB is already running
 if pgrep -x "mongod" > /dev/null; then
-    echo -e "${RED}MongoDB is already running!${RESET}"
+    error "MongoDB is already running!"
     echo "Please stop the MongoDB service before running this script."
     exit 1
 fi
 
 # Check if a MongoDB directory exists
 if [ -d "$MONGODB_DIR/db" ]; then
-    echo -e "${YELLOW}Existing MongoDB directory found.${RESET}"
-    read -p "Do you want to back it up before overwriting? (y/n): " backup_choice
-
-    if [[ "$backup_choice" == "y" ]]; then
+    warn "Existing MongoDB directory found."
+    if confirm "Do you want to back it up before overwriting?"; then
         echo "Backing up existing MongoDB database..."
-        tar -czvf "$HOME/mongodb_backup_$(date +%Y%m%d_%H%M%S).tar.gz" "$MONGODB_DIR/db"
-        echo -e "${GREEN}Backup completed successfully.${RESET}"
+        tar -czf "$HOME/mongodb_backup_$(date +%Y%m%d_%H%M%S).tar.gz" -C "$MONGODB_DIR" db
+        info "Backup completed successfully."
     fi
 
     echo "Overwriting existing MongoDB database..."
-    rm -rf "$MONGODB_DIR/db/*"  # Clear existing database files
+    find "$MONGODB_DIR/db" -mindepth 1 -delete
 fi
 
-# Ask user which MongoDB version to install
-echo -e "${GREEN}Select MongoDB version to install:${RESET}"
-echo "1) 6.0"
-echo "2) 7.0"
-read -p "Enter choice (1 or 2): " version_choice
+# ---------------------------------------------------------------------------
+# DETECT OS & ARCHITECTURE
+# ---------------------------------------------------------------------------
+detect_os_key() {
+    if [ ! -r /etc/os-release ]; then
+        echo ""
+        return
+    fi
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    local id="${ID:-}" id_like="${ID_LIKE:-}" version="${VERSION_ID:-}"
+    local major="${version%%.*}"
 
-case $version_choice in
-    1) MONGO_VERSION="mongodb-linux-x86_64-rhel90-6.0.22.tgz";;
-    2) MONGO_VERSION="mongodb-linux-x86_64-rhel90-7.0.19.tgz";;
-    *) echo -e "${RED}Invalid choice. Exiting.${RESET}"; exit 1;;
+    case "$id" in
+        rhel|centos|rocky|almalinux|ol|fedora)
+            echo "rhel${major}" ;;
+        ubuntu)
+            echo "ubuntu${version//./}" ;;
+        debian)
+            echo "debian${major}" ;;
+        amzn)
+            case "$version" in
+                2023) echo "amazon2023" ;;
+                2)    echo "amazon2" ;;
+                *)    echo "amazon" ;;
+            esac ;;
+        sles|opensuse-leap)
+            echo "suse${major}" ;;
+        *)
+            if [[ "$id_like" == *rhel* || "$id_like" == *fedora* ]]; then
+                echo "rhel${major}"
+            else
+                echo ""
+            fi ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)   echo "x86_64" ;;
+        aarch64|arm64)  echo "aarch64" ;;
+        *)              echo "" ;;
+    esac
+}
+
+OS_KEY=$(detect_os_key)
+ARCH=$(detect_arch)
+
+if [ -z "$OS_KEY" ] || [ -z "$ARCH" ]; then
+    error "Could not confidently detect this server's OS/architecture."
+    error "Please check https://www.mongodb.com/try/download/community-edition and install manually."
+    exit 1
+fi
+info "Detected platform: ${OS_KEY} / ${ARCH}"
+
+# mongosh's feed labels ARM as "arm64" instead of "aarch64"
+MONGOSH_ARCH="$ARCH"
+[ "$ARCH" = "aarch64" ] && MONGOSH_ARCH="arm64"
+
+# ---------------------------------------------------------------------------
+# JSON RESOLVER (matches this server against MongoDB's official release feeds)
+# ---------------------------------------------------------------------------
+RESOLVE_JS="$SCRATCH_DIR/resolve.js"
+cat > "$RESOLVE_JS" <<'JAVASCRIPT'
+'use strict';
+const fs = require('fs');
+
+const [, , feedPath, arch, matchField, wantedRaw, distroFilter, versionPrefix, edition] = process.argv;
+
+function familyKey(raw) {
+  if (!raw) return raw;
+  if (/^rhel10/.test(raw)) return 'rhel10';
+  if (/^rhel9/.test(raw)) return 'rhel9';
+  if (/^rhel8/.test(raw)) return 'rhel8';
+  if (/^rhel7/.test(raw)) return 'rhel7';
+  return raw;
+}
+
+let feed;
+try {
+  feed = JSON.parse(fs.readFileSync(feedPath, 'utf8'));
+} catch (err) {
+  console.error(`Could not read/parse feed ${feedPath}: ${err.message}`);
+  process.exit(2);
+}
+
+const wanted = familyKey(wantedRaw);
+
+let versions = (feed.versions || []).filter((v) => /^\d+\.\d+\.\d+$/.test(v.version));
+if (versionPrefix) {
+  versions = versions.filter((v) => v.version === versionPrefix || v.version.startsWith(`${versionPrefix}.`));
+}
+
+versions.sort((a, b) => {
+  const pa = a.version.split('.').map(Number);
+  const pb = b.version.split('.').map(Number);
+  for (let i = 0; i < 3; i += 1) {
+    const diff = (pb[i] || 0) - (pa[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+});
+
+for (const v of versions) {
+  if (v.release_candidate) continue;
+  if (v.production_release === false) continue;
+  for (const d of v.downloads || []) {
+    if (d.arch !== arch) continue;
+    if (distroFilter && d.distro !== distroFilter) continue;
+    if (matchField && familyKey(d[matchField]) !== wanted) continue;
+    // "targeted" is MongoDB's internal name for the free Community edition;
+    // "enterprise" builds require a commercial license. Never fall back
+    // silently to Enterprise when Community was requested.
+    if (edition && d.edition && d.edition !== edition) continue;
+    if (!d.archive || !d.archive.url) continue;
+    console.log([v.version, d.archive.url, d.archive.sha256 || ''].join('\t'));
+    process.exit(0);
+  }
+}
+process.exit(1);
+JAVASCRIPT
+
+resolve_download() {
+    # args: feed_file arch match_field wanted_key distro_filter version_prefix edition
+    node "$RESOLVE_JS" "$1" "$2" "$3" "$4" "$5" "$6" "$7"
+}
+
+# ---------------------------------------------------------------------------
+# SELECT MONGODB VERSION
+# ---------------------------------------------------------------------------
+info "Select MongoDB version to install:"
+echo "  1) 8.0 - Long-Term/Major Release, supported until Oct 2029 (recommended)"
+echo "  2) 7.0 - Previous Major Release, supported until Aug 2027"
+read -r -p "Enter choice [1]: " version_choice
+version_choice=${version_choice:-1}
+
+case "$version_choice" in
+    1) MONGO_BRANCH="8.0" ;;
+    2) MONGO_BRANCH="7.0" ;;
+    *) error "Invalid choice. Exiting."; exit 1 ;;
 esac
 
+# ---------------------------------------------------------------------------
+# RESOLVE & DOWNLOAD MONGODB SERVER
+# ---------------------------------------------------------------------------
+info "Looking up the correct MongoDB ${MONGO_BRANCH} build for this server..."
+SERVER_FEED="$SCRATCH_DIR/current.json"
+download "https://downloads.mongodb.org/current.json" "$SERVER_FEED"
+
+if ! RESULT=$(resolve_download "$SERVER_FEED" "$ARCH" target "$OS_KEY" "" "$MONGO_BRANCH" targeted); then
+    error "Could not find a MongoDB ${MONGO_BRANCH} build for ${OS_KEY}/${ARCH} in MongoDB's release catalog."
+    error "Please check https://www.mongodb.com/try/download/community-edition and install manually."
+    exit 1
+fi
+IFS=$'\t' read -r MONGO_VERSION MONGO_URL MONGO_SHA256 <<< "$RESULT"
+info "Resolved MongoDB ${MONGO_VERSION} (${MONGO_URL})"
+
 # CREATE REQUIRED DIRS
-mkdir -p "$MONGODB_DIR/log" "$MONGODB_DIR/run" "$MONGODB_DIR/db"
+mkdir -p "$MONGODB_DIR/log" "$MONGODB_DIR/run" "$MONGODB_DIR/db" "$MONGODB_DIR/mongosh" "$MONGODB_DIR/tools"
+cd "$MONGODB_DIR" || { error "Failed to change directory!"; exit 1; }
 
-# Change to MongoDB directory
-cd "$MONGODB_DIR" || { echo -e "${RED}Failed to change directory!${RESET}"; exit 1; }
+MONGO_ARCHIVE="$SCRATCH_DIR/$(basename "$MONGO_URL")"
+download "$MONGO_URL" "$MONGO_ARCHIVE"
+verify_checksum "$MONGO_ARCHIVE" "$MONGO_SHA256"
+tar -zxf "$MONGO_ARCHIVE" -C "$MONGODB_DIR"
 
-# GET MONGODB
-wget "https://fastdl.mongodb.org/linux/$MONGO_VERSION" || { echo "Download failed!"; exit 1; }
-tar -zxvf "$MONGO_VERSION" -C "$MONGODB_DIR"  # Extract directly to the MongoDB directory
+set +o pipefail
+EXTRACTED_DIR=$(tar -tzf "$MONGO_ARCHIVE" | head -n 1 | cut -d/ -f1)
+set -o pipefail
+ln -sfn "$MONGODB_DIR/$EXTRACTED_DIR" "$MONGODB_DIR/mongodb-binary"
 
-# Correctly identify the extracted folder
-if [[ $version_choice == 1 ]]; then
-    EXTRACTED_DIR="mongodb-linux-x86_64-rhel90-6.0.22"
-elif [[ $version_choice == 2 ]]; then
-    EXTRACTED_DIR="mongodb-linux-x86_64-rhel90-7.0.19"
+if ! "$MONGODB_DIR/mongodb-binary/bin/mongod" --version > /dev/null 2>&1; then
+    error "The downloaded mongod binary failed to run on this system (missing shared libraries?)."
+    exit 1
+fi
+info "MongoDB ${MONGO_VERSION} downloaded and verified."
+
+# ---------------------------------------------------------------------------
+# RESOLVE & DOWNLOAD MONGOSH
+# ---------------------------------------------------------------------------
+info "Fetching the latest mongosh build..."
+MONGOSH_FEED="$SCRATCH_DIR/mongosh.json"
+download "https://downloads.mongodb.com/compass/mongosh.json" "$MONGOSH_FEED"
+
+if ! RESULT=$(resolve_download "$MONGOSH_FEED" "$MONGOSH_ARCH" "" "" linux "" ""); then
+    error "Could not resolve a mongosh build for ${MONGOSH_ARCH}."
+    exit 1
+fi
+IFS=$'\t' read -r MONGOSH_VERSION MONGOSH_URL MONGOSH_SHA256 <<< "$RESULT"
+
+MONGOSH_ARCHIVE="$SCRATCH_DIR/mongosh.tgz"
+download "$MONGOSH_URL" "$MONGOSH_ARCHIVE"
+verify_checksum "$MONGOSH_ARCHIVE" "$MONGOSH_SHA256"
+tar -zxf "$MONGOSH_ARCHIVE" -C "$MONGODB_DIR/mongosh" --strip-components=1
+info "mongosh ${MONGOSH_VERSION} installed."
+
+# ---------------------------------------------------------------------------
+# RESOLVE & DOWNLOAD MONGODB DATABASE TOOLS
+# ---------------------------------------------------------------------------
+info "Fetching the latest MongoDB Database Tools build..."
+TOOLS_FEED="$SCRATCH_DIR/tools-release.json"
+download "https://downloads.mongodb.org/tools/db/release.json" "$TOOLS_FEED"
+
+if RESULT=$(resolve_download "$TOOLS_FEED" "$ARCH" name "$OS_KEY" "" "" ""); then
+    IFS=$'\t' read -r TOOLS_VERSION TOOLS_URL TOOLS_SHA256 <<< "$RESULT"
+    TOOLS_ARCHIVE="$SCRATCH_DIR/tools.tgz"
+    download "$TOOLS_URL" "$TOOLS_ARCHIVE"
+    verify_checksum "$TOOLS_ARCHIVE" "$TOOLS_SHA256"
+    tar -zxf "$TOOLS_ARCHIVE" -C "$MONGODB_DIR/tools" --strip-components=1
+    info "MongoDB Database Tools ${TOOLS_VERSION} installed."
+else
+    warn "Could not find a matching MongoDB Database Tools build for ${OS_KEY}/${ARCH}. Skipping (optional)."
 fi
 
-# Create the symlink to the extracted directory
-ln -s "$MONGODB_DIR/$EXTRACTED_DIR" "$MONGODB_DIR/mongodb-binary"
+# ---------------------------------------------------------------------------
+# UPDATE PATH (idempotent)
+# ---------------------------------------------------------------------------
+PROFILE="$HOME/.bash_profile"
+touch "$PROFILE"
+if ! grep -qF "$MONGODB_DIR/mongosh/bin" "$PROFILE"; then
+    echo "export PATH=\"\$PATH:$MONGODB_DIR/mongosh/bin:$MONGODB_DIR/tools/bin\"" >> "$PROFILE"
+    info "Updated PATH in $PROFILE."
+fi
+# shellcheck disable=SC1090
+source "$PROFILE"
 
-# CREATE DIRECTORIES FOR MONGOSH AND TOOLS
-mkdir -p "$MONGODB_DIR/mongosh" "$MONGODB_DIR/tools"
-
-# GET MONGOSH
-wget https://downloads.mongodb.com/compass/mongosh-1.5.2-linux-x64.tgz -O "$MONGODB_DIR/mongosh/mongosh.tgz" || { echo "Download failed!"; exit 1; }
-tar -zxvf "$MONGODB_DIR/mongosh/mongosh.tgz" -C "$MONGODB_DIR/mongosh" --strip-components=1
-echo 'export PATH=$PATH:$MONGODB_DIR/mongosh/bin' >> "$HOME/.bash_profile"
-echo "Updating PATH to include mongosh..."
-source $HOME/.bash_profile
-echo -e "${GREEN}Mongosh installed successfully.${RESET}"
-sleep 1
-
+# ---------------------------------------------------------------------------
 # CREATE MONGO.CFG
+# ---------------------------------------------------------------------------
 echo "Creating MongoDB configuration file..."
 sleep 1
+
+# Ask user for memory limit
+info "Select memory limit for MongoDB:"
+echo "  1) 256M"
+echo "  2) 512M"
+echo "  3) 1G"
+echo "  4) 2G"
+echo "  5) 3G"
+read -r -p "Enter choice [3]: " memory_choice
+memory_choice=${memory_choice:-3}
+
+# WiredTiger's cache is kept well under the PM2 memory limit so MongoDB
+# doesn't get OOM-killed and restart-looped by PM2 on small memory plans.
+case "$memory_choice" in
+    1) MEMORY="256M"; CACHE_SIZE_GB="0.25" ;;
+    2) MEMORY="512M"; CACHE_SIZE_GB="0.25" ;;
+    3) MEMORY="1G";   CACHE_SIZE_GB="0.5"  ;;
+    4) MEMORY="2G";   CACHE_SIZE_GB="1"    ;;
+    5) MEMORY="3G";   CACHE_SIZE_GB="1.5"  ;;
+    *) error "Invalid choice. Exiting."; exit 1 ;;
+esac
+
 cat > "$MONGODB_DIR/mongo.cfg" << ENDOFFILE
 processManagement:
     fork: false
@@ -134,34 +422,19 @@ storage:
     wiredTiger:
         engineConfig:
             journalCompressor: snappy
-            cacheSizeGB: 1
+            cacheSizeGB: $CACHE_SIZE_GB
         collectionConfig:
             blockCompressor: snappy
 ENDOFFILE
 
-echo -e "${GREEN}Mongo CFG created.${RESET}"
+info "Mongo CFG created."
 sleep 1
 
-# Ask user for memory limit
-echo -e "${GREEN}Select memory limit for MongoDB:${RESET}"
-echo "1) 256M"
-echo "2) 512M"
-echo "3) 1G"
-echo "4) 2G"
-echo "5) 3G"
-read -p "Enter choice (1-5): " memory_choice
-
-case $memory_choice in
-    1) MEMORY="256M";;
-    2) MEMORY="512M";;
-    3) MEMORY="1G";;
-    4) MEMORY="2G";;
-    5) MEMORY="3G";;
-    *) echo -e "${RED}Invalid choice. Exiting.${RESET}"; exit 1;;
-esac
-
 # Ask user for PM2 app name
-read -p "Enter a name for the PM2 app:" pm2_app_name
+read -r -p "Enter a name for the PM2 app [mongodb]: " pm2_app_name
+pm2_app_name=${pm2_app_name:-mongodb}
+pm2_app_name=$(echo "$pm2_app_name" | tr -cd 'A-Za-z0-9_-')
+[ -z "$pm2_app_name" ] && pm2_app_name="mongodb"
 
 # CREATE JSON FOR PM2
 echo "Creating MongoDB PM2 JSON..."
@@ -171,93 +444,105 @@ cat > "$MONGODB_DIR/${pm2_app_name}.pm2.json" << ENDOFFILE
   "apps": [{
     "name": "$pm2_app_name",
     "script": "$MONGODB_DIR/mongodb-binary/bin/mongod",
-    "args": "--config $MONGODB_DIR/mongo.cfg --auth",
+    "args": ["--config", "$MONGODB_DIR/mongo.cfg", "--auth"],
+    "interpreter": "none",
     "cwd": "$MONGODB_DIR",
     "max_memory_restart": "$MEMORY"
   }]
 }
 ENDOFFILE
 
-echo -e "${GREEN}MongoDB PM2 JSON created.${RESET}"
+info "MongoDB PM2 JSON created."
 sleep 1
 
 # START MONGODB FIRST TIME
 echo "Starting MongoDB..."
 sleep 1
-pm2 start "$MONGODB_DIR/${pm2_app_name}.pm2.json" || { echo -e "${RED}Failed to start MongoDB!${RESET}"; exit 1; }
+pm2 start "$MONGODB_DIR/${pm2_app_name}.pm2.json" || { error "Failed to start MongoDB!"; exit 1; }
 
 # WAIT FOR MONGODB TO START
 echo "Checking if MongoDB is running..."
-max_attempts=30  # Maximum number of attempts
+max_attempts=30
 attempt=0
 
-while ! pgrep -x mongod > /dev/null; do   
+while ! pgrep -x mongod > /dev/null; do
     if [ "$attempt" -ge "$max_attempts" ]; then
-        echo -e "${RED}MongoDB did not start in time. Exiting.${RESET}"
+        error "MongoDB did not start in time. Check the logs with: pm2 logs $pm2_app_name"
         exit 1
     fi
-    sleep 1  # Wait for 1 second before checking again
+    sleep 1
     attempt=$((attempt + 1))
 done
 
-echo -e "${GREEN}MongoDB is up and running.${RESET}"
+info "MongoDB is up and running."
 sleep 1
 
 echo "Checking if mongosh is installed..."
-
-# CHECK IF MONGOSH IS INSTALLED
 if ! command -v mongosh &> /dev/null; then
-    echo -e "${RED}Mongosh is not installed or path not added. Please install it manually.${RESET}"
+    error "Mongosh is not installed or path not added. Please install it manually."
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
 # CREATE ADMIN DB USER
-echo -e "${GREEN}Creating new root user in ADMIN database.${RESET}"
-read -p "Enter new ROOT username: " username
-read -sp "Enter new ROOT password: " password
+# ---------------------------------------------------------------------------
+info "Creating new root user in ADMIN database."
+read -r -p "Enter new ROOT username: " username
+until [ -n "$username" ]; do read -r -p "Username cannot be empty. Enter new ROOT username: " username; done
+read -rsp "Enter new ROOT password: " password
 echo
+until [ -n "$password" ]; do read -rsp "Password cannot be empty. Enter new ROOT password: " password; echo; done
 
-# Create the root user using mongosh
-mongosh $USER.loopback.zonevs.eu:5679/admin --eval "db.createUser({
-    user: \"$username\",
-    pwd: \"$password\",
-    roles: [{ role: \"root\", db: \"admin\" }]
-})"
+# Credentials are passed via environment variables (not string-interpolated
+# into the --eval script) so special characters can't break out of the JS
+# string or inject arbitrary commands.
+MM_USER="$username" MM_PASS="$password" mongosh "$LOOPBACK:5679/admin" --quiet --eval '
+db.createUser({
+    user: process.env.MM_USER,
+    pwd: process.env.MM_PASS,
+    roles: [{ role: "root", db: "admin" }]
+});
+'
 
 # WARNING ABOUT CREATING A NEW USER
-echo -e "${YELLOW}WARNING: It is recommended to create a new user with read/write permissions.${RESET}"
-read -p "Do you want to create a new user with limited permissions? (y/n): " create_user
+warn "WARNING: It is recommended to create a new user with read/write permissions."
+if confirm "Do you want to create a new user with limited permissions?"; then
+    read -r -p "Enter new USERNAME for LIMITED access: " new_username
+    until [ -n "$new_username" ]; do read -r -p "Username cannot be empty. Enter new USERNAME for LIMITED access: " new_username; done
+    read -rsp "Enter new PASSWORD for LIMITED access: " new_password
+    echo
+    until [ -n "$new_password" ]; do read -rsp "Password cannot be empty. Enter new PASSWORD for LIMITED access: " new_password; echo; done
+    read -r -p "Enter the name of the DATABASE for the LIMITED user: " db_name
+    until [ -n "$db_name" ]; do read -r -p "Database name cannot be empty. Enter the name of the DATABASE for the LIMITED user: " db_name; done
 
-if [[ "$create_user" == "y" ]]; then
-    read -p "Enter new USERNAME for LIMITED access: " new_username
-    read -sp "Enter new PASSWORD for LIMITED access: " new_password
-    echo
-    read -p "Enter the name of the DATABASE for the LIMITED user: " db_name
-    echo
-    
-    # Create the new user with limited access using the root user's credentials
-    mongosh --username "$username" --password "$password" $USER.loopback.zonevs.eu:5679/admin --eval "db.createUser({
-        user: \"$new_username\",
-        pwd: \"$new_password\",
-        roles: [{ role: \"readWrite\", db: \"$db_name\" }]
-    })"
-    echo -e "${GREEN}New user created in $db_name with read/write permissions.${RESET}"
+    MM_ROOT_USER="$username" MM_ROOT_PASS="$password" MM_NEW_USER="$new_username" MM_NEW_PASS="$new_password" MM_DB_NAME="$db_name" \
+        mongosh "$LOOPBACK:5679/admin" --quiet --eval '
+db.auth(process.env.MM_ROOT_USER, process.env.MM_ROOT_PASS);
+db.getSiblingDB(process.env.MM_DB_NAME).createUser({
+    user: process.env.MM_NEW_USER,
+    pwd: process.env.MM_NEW_PASS,
+    roles: [{ role: "readWrite", db: process.env.MM_DB_NAME }]
+});
+'
+    info "New user created in $db_name with read/write permissions."
     sleep 1
 fi
 
-# DO NEXT COMMENTS
-echo -e "${GREEN}MongoDB installation completed successfully.${RESET}"
+# ---------------------------------------------------------------------------
+# WRAP UP
+# ---------------------------------------------------------------------------
+info "MongoDB installation completed successfully."
 sleep 1
-echo -e "${YELLOW}IMPORTANT: Setup MongoDB as new PM2 app at Zone.eu${RESET}"
+warn "IMPORTANT: Setup MongoDB as new PM2 app at Zone.eu"
 echo "Webhosting -> PM2 and Node.js -> Add new application"
 echo "Path for the app: $MONGODB_DIR/${pm2_app_name}.pm2.json"
 echo "App name: $pm2_app_name"
 echo "Memory limit: $MEMORY"
 echo "Start the app and check the logs for any errors."
 
-# CLOSE MONGO USING PM2
+# CLOSE MONGO USING PM2 (the app will be re-added through the My Zone panel)
 echo "Shutting down MongoDB using PM2..."
-pm2 stop "$pm2_app_name" || { echo "Failed to stop MongoDB!"; exit 1; }
+pm2 stop "$pm2_app_name" || { error "Failed to stop MongoDB!"; exit 1; }
 echo "Deleting MongoDB PM2 app..."
-pm2 delete "$pm2_app_name" || { echo "Failed to delete MongoDB!"; exit 1; }
-echo -e "${GREEN}All done. Exiting script.${RESET}"
+pm2 delete "$pm2_app_name" || { error "Failed to delete MongoDB!"; exit 1; }
+info "All done. Exiting script."

--- a/scripts/mongo-magic/.mongo-magic.sh
+++ b/scripts/mongo-magic/.mongo-magic.sh
@@ -71,8 +71,8 @@ echo "2) 7.0"
 read -p "Enter choice (1 or 2): " version_choice
 
 case $version_choice in
-    1) MONGO_VERSION="mongodb-linux-x86_64-rhel80-6.0.0.tgz";;
-    2) MONGO_VERSION="mongodb-linux-x86_64-rhel80-7.0.0.tgz";;
+    1) MONGO_VERSION="mongodb-linux-x86_64-rhel90-6.0.22.tgz";;
+    2) MONGO_VERSION="mongodb-linux-x86_64-rhel90-7.0.19.tgz";;
     *) echo -e "${RED}Invalid choice. Exiting.${RESET}"; exit 1;;
 esac
 
@@ -88,9 +88,9 @@ tar -zxvf "$MONGO_VERSION" -C "$MONGODB_DIR"  # Extract directly to the MongoDB 
 
 # Correctly identify the extracted folder
 if [[ $version_choice == 1 ]]; then
-    EXTRACTED_DIR="mongodb-linux-x86_64-rhel80-6.0.0"
+    EXTRACTED_DIR="mongodb-linux-x86_64-rhel90-6.0.22"
 elif [[ $version_choice == 2 ]]; then
-    EXTRACTED_DIR="mongodb-linux-x86_64-rhel80-7.0.0"
+    EXTRACTED_DIR="mongodb-linux-x86_64-rhel90-7.0.19"
 fi
 
 # Create the symlink to the extracted directory
@@ -129,8 +129,6 @@ systemLog:
     logAppend: true
 storage:
     dbPath: "$MONGODB_DIR/db/"
-    journal:
-        enabled: true
     directoryPerDB: true
     engine: wiredTiger
     wiredTiger:

--- a/scripts/mongo-magic/README.md
+++ b/scripts/mongo-magic/README.md
@@ -6,8 +6,11 @@ Mongo Magic is a bash script designed to automate the installation and setup of 
 ## Features
 - Detects the server's OS and architecture and cross-checks it against MongoDB's
   official release catalog (`downloads.mongodb.org`) to pick the exact right
-  binary, rather than guessing a filename. If it can't be sure, it aborts
-  instead of installing the wrong binary.
+  binary, rather than guessing a filename. When the OS isn't one MongoDB
+  publishes a build for (e.g. Zone.eu's own ZoneOS, which has no rpm/dpkg
+  and no equivalent in MongoDB's catalog), it probes a short list of
+  known-compatible builds and verifies each one by actually running `mongod`,
+  rather than trusting a name match. It only aborts if nothing it tries runs.
 - Verifies the SHA-256 checksum of every downloaded artifact.
 - Only ever installs the free Community edition (never the commercial Enterprise
   build, even though both are listed side by side in MongoDB's feeds).
@@ -27,9 +30,14 @@ Mongo Magic is a bash script designed to automate the installation and setup of 
 
 ## Supported platforms
 The script auto-detects RHEL-family (RHEL, CentOS, Rocky, AlmaLinux), Debian,
-Ubuntu, Amazon Linux, and SUSE hosts on x86_64/aarch64. If your server isn't on
-this list, or MongoDB doesn't publish a matching build, the script stops and
-points you to the [MongoDB Download Center](https://www.mongodb.com/try/download/community-edition)
+Ubuntu, Amazon Linux, and SUSE hosts on x86_64/aarch64. On hosts it can't
+confidently name -- notably Zone.eu's own ZoneOS, a Gentoo/ChromiumOS-derived
+image with no package manager at all -- it instead tries a short list of
+known-compatible builds (RHEL 9/8, Ubuntu 24.04/22.04, Debian 12/11, Amazon
+Linux 2023) and keeps whichever one actually runs `mongod` successfully. If
+none of them run, or MongoDB doesn't publish a matching build for the
+architecture, the script stops and points you to the
+[MongoDB Download Center](https://www.mongodb.com/try/download/community-edition)
 instead of guessing.
 
 ## Installation

--- a/scripts/mongo-magic/README.md
+++ b/scripts/mongo-magic/README.md
@@ -4,16 +4,33 @@
 Mongo Magic is a bash script designed to automate the installation and setup of MongoDB on Zone.eu servers. The script provides various options for configuration, ensuring a smooth installation process tailored to your needs.
 
 ## Features
+- Detects the server's OS and architecture and cross-checks it against MongoDB's
+  official release catalog (`downloads.mongodb.org`) to pick the exact right
+  binary, rather than guessing a filename. If it can't be sure, it aborts
+  instead of installing the wrong binary.
+- Verifies the SHA-256 checksum of every downloaded artifact.
+- Only ever installs the free Community edition (never the commercial Enterprise
+  build, even though both are listed side by side in MongoDB's feeds).
+- Lets you choose between MongoDB 8.0 (current Long-Term/Major Release,
+  recommended) and 7.0 (previous Major Release, still supported).
+- Always installs the latest mongosh and MongoDB Database Tools builds.
 - Checks for existing MongoDB instances to prevent conflicts.
 - Offers to back up the current database before installation.
-- Allows selection between MongoDB versions 6.0 and 7.0.
+- Scales the WiredTiger cache size to the chosen PM2 memory limit so MongoDB
+  doesn't get killed in a restart loop on small memory plans.
 - Lets you choose the memory allocation for MongoDB from predefined options (256M, 512M, 1G, 2G, 3G).
 - Enables specification of a custom PM2 app name.
-- Automatically checks for and installs compatible MongoDB tools.
 - Prompts for the creation of a new user with root access and an optional additional user with read/write permissions.
 - Prompts the user to name the new database with limited access.
 - Provides instructions for setting up MongoDB as a new PM2 app on Zone.eu servers.
-- Adds the mongosh binary to the PATH for easy access.
+- Adds mongosh and the MongoDB Database Tools to PATH for easy access.
+
+## Supported platforms
+The script auto-detects RHEL-family (RHEL, CentOS, Rocky, AlmaLinux), Debian,
+Ubuntu, Amazon Linux, and SUSE hosts on x86_64/aarch64. If your server isn't on
+this list, or MongoDB doesn't publish a matching build, the script stops and
+points you to the [MongoDB Download Center](https://www.mongodb.com/try/download/community-edition)
+instead of guessing.
 
 ## Installation
 


### PR DESCRIPTION
Updates the MongoDB installation script for RHEL9 and modernizes it end-to-end:

- Resolves the correct MongoDB/mongosh/Database Tools binary at install time against MongoDB's official release feeds (downloads.mongodb.org), instead of relying on hardcoded filenames that MongoDB has silently renamed in the past.
- Verifies the SHA-256 checksum of every downloaded artifact.
- Defaults to MongoDB 8.0 (current LTS/Major Release) with 7.0 as the alternative; drops EOL 6.0.
- Actually installs the MongoDB Database Tools, which were advertised in the README but never implemented.
- On hosts that don't correspond to any distro MongoDB publishes a build for -- notably Zone.eu's own ZoneOS host image, which has no rpm/dpkg and no equivalent in MongoDB's catalog -- the script probes an ordered list of known-compatible builds (RHEL 9/8, Ubuntu 24.04/22.04, Debian 12/11, Amazon Linux 2023) and keeps whichever one actually runs mongod/mongodump, instead of trusting a name match that may not hold.
- Fixes several bugs: the database-wipe glob never expanded due to quoting, the mongosh PATH export was written unexpanded into .bash_profile, WiredTiger cache size ignored the chosen PM2 memory limit (causing OOM restart loops on small plans), and admin credentials were interpolated directly into mongosh --eval strings instead of passed via environment variables.
- Removes the redundant journal option from the MongoDB configuration file (enabled by default).